### PR TITLE
upload api with mime multipart, auth middleware

### DIFF
--- a/cmd/godinary/godinary.go
+++ b/cmd/godinary/godinary.go
@@ -16,6 +16,7 @@ import (
 func setupConfig() {
 	// flags setup
 	flag.String("domain", "", "Domain to validate with Host header, it will deny any other request (if port is not standard must be passed as host:port)")
+	flag.String("auth", "", "List of apikey,apisecret (one per line) allowed to use API")
 	flag.String("sentry_url", "", "Sentry DSN for error tracking")
 	flag.String("release", "", "Release hash to notify sentry")
 	flag.String("allow_hosts", "", "Domains authorized to ask godinary separated by commas (A comma at the end allows empty referers)")
@@ -69,6 +70,16 @@ func main() {
 		MaxRequestPerDomain: viper.GetInt("max_request_domain"),
 		SSLDir:              viper.GetString("ssl_dir"),
 		CDNTTL:              viper.GetString("cdn_ttl"),
+	}
+	opts.APIAuth = make(map[string]string)
+	auth := viper.GetString("auth")
+	if auth != "" {
+		parts := strings.Split(auth, ",")
+		if len(parts) == 2 {
+			opts.APIAuth[parts[0]] = parts[1]
+		} else {
+			log.Fatalln("Invalid auth ", parts)
+		}
 	}
 
 	if viper.GetString("storage") == "gs" {

--- a/http/api.go
+++ b/http/api.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+
+// UploadAPIResponse holds the response json model for apiupload
+type UploadAPIResponse struct {
+	URL   string `json:"url"`
+	Error string `json:"error"`
+}
+
+func diverseName(name string) (string, error) {
+	n := 8
+	b := make([]rune, n)
+	rand.Seed(time.Now().UnixNano())
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+
+	parts := strings.Split(name, ".")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid name %s", name)
+	}
+	newName := fmt.Sprintf("%s-%s.%s", parts[0], string(b), parts[1])
+	return newName, nil
+}
+
+func writeErr(w http.ResponseWriter, msg string, status int) {
+	b, err := json.Marshal(&UploadAPIResponse{URL: "", Error: msg})
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(status)
+		w.Write(b)
+	}
+}
+
+// APIUpload handles image uploads from API users
+func APIUpload(opts *ServerOpts) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != "POST" {
+			writeErr(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		r.ParseMultipartForm(32 << 20)
+		file, fileHeader, err := r.FormFile("file")
+		if err != nil {
+			log.Printf("can not retrieve file: %v", err)
+			writeErr(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		defer file.Close()
+
+		name, err := diverseName(fileHeader.Filename)
+		if err != nil {
+			log.Printf("can not retrieve file: %v", err)
+			writeErr(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+
+		ht := sha256.New()
+		ht.Write([]byte(name))
+		hash := hex.EncodeToString(ht.Sum(nil))
+
+		opts.StorageDriver.Init()
+		reader, err := opts.StorageDriver.NewReader(hash, "upload/")
+		if err == nil {
+			reader.Close()
+			writeErr(w, "Image already exists", http.StatusBadRequest)
+			return
+		}
+
+		body, err := ioutil.ReadAll(file)
+		if err != nil {
+			log.Printf("can not retrieve file: %v", err)
+			writeErr(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		opts.StorageDriver.Write(body, hash, "upload/")
+		finalURL := fmt.Sprintf("https://%s/image/upload/f_auto/%s", opts.Domain, name)
+		fmt.Println("Uploaded filename", finalURL)
+		b, err := json.Marshal(&UploadAPIResponse{URL: finalURL, Error: ""})
+		w.Write(b)
+	}
+}

--- a/http/server.go
+++ b/http/server.go
@@ -160,7 +160,6 @@ func refererValidator(allowedReferers []string, next http.HandlerFunc) http.Hand
 // auth validates API_KEY and API_SIGNATURE against shared API_SECRET
 func auth(auth map[string]string, next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// allowed := false
 		APIKey := r.FormValue("apikey")
 		signature := r.FormValue("signature")
 		timestamp := r.FormValue("timestamp")

--- a/http/server.go
+++ b/http/server.go
@@ -1,6 +1,9 @@
 package http
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -32,6 +35,7 @@ type ServerOpts struct {
 	GCEProject          string
 	GSBucket            string
 	GSCredentials       string
+	APIAuth             map[string]string
 }
 
 // ------------------------------------
@@ -53,6 +57,7 @@ func Serve(opts *ServerOpts) {
 	mux.Handle("/up", Middleware(Up, opts))
 	mux.Handle("/image/fetch/", Middleware(Fetch(opts), opts))
 	mux.Handle("/image/upload/", Middleware(Upload(opts), opts))
+	mux.Handle("/v1_0/image/upload", AuthMiddleware(APIUpload(opts), opts))
 	server := http.Server{
 		Addr:    ":" + opts.Port,
 		Handler: mux,
@@ -105,6 +110,11 @@ func Middleware(handler func(w http.ResponseWriter, r *http.Request), opts *Serv
 	return raven.RecoveryHandler(logger(domainValidator(opts.Domain, refererValidator(opts.AllowedReferers, handler))))
 }
 
+// AuthMiddleware composes all middlewares + auth
+func AuthMiddleware(handler func(w http.ResponseWriter, r *http.Request), opts *ServerOpts) http.HandlerFunc {
+	return raven.RecoveryHandler(logger(domainValidator(opts.Domain, refererValidator(opts.AllowedReferers, auth(opts.APIAuth, handler)))))
+}
+
 // domainValidator is a middleware to check Host Header against configured domain
 func domainValidator(domain string, next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,6 +154,36 @@ func refererValidator(allowedReferers []string, next http.HandlerFunc) http.Hand
 				return
 			}
 		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// auth validates API_KEY and API_SIGNATURE against shared API_SECRET
+func auth(auth map[string]string, next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// allowed := false
+		APIKey := r.FormValue("apikey")
+		signature := r.FormValue("signature")
+		timestamp := r.FormValue("timestamp")
+		if APIKey == "" || signature == "" {
+			http.Error(w, "missing", http.StatusForbidden)
+			return
+		}
+		fmt.Println(APIKey, signature)
+		storedSecret, ok := auth[APIKey]
+		if !ok {
+			http.Error(w, "notok", http.StatusForbidden)
+			return
+		}
+
+		ht := sha256.New()
+		ht.Write([]byte(APIKey + timestamp + storedSecret))
+		hash := hex.EncodeToString(ht.Sum(nil))
+		if hash != signature {
+			http.Error(w, hash, http.StatusForbidden)
+			return
+		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/http/server.go
+++ b/http/server.go
@@ -3,7 +3,6 @@ package http
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -169,7 +168,6 @@ func auth(auth map[string]string, next http.HandlerFunc) http.HandlerFunc {
 			http.Error(w, "missing", http.StatusForbidden)
 			return
 		}
-		fmt.Println(APIKey, signature)
 		storedSecret, ok := auth[APIKey]
 		if !ok {
 			http.Error(w, "notok", http.StatusForbidden)

--- a/http/server.go
+++ b/http/server.go
@@ -164,12 +164,12 @@ func auth(auth map[string]string, next http.HandlerFunc) http.HandlerFunc {
 		signature := r.FormValue("signature")
 		timestamp := r.FormValue("timestamp")
 		if APIKey == "" || signature == "" {
-			http.Error(w, "missing", http.StatusForbidden)
+			http.Error(w, "", http.StatusForbidden)
 			return
 		}
 		storedSecret, ok := auth[APIKey]
 		if !ok {
-			http.Error(w, "notok", http.StatusForbidden)
+			http.Error(w, "", http.StatusForbidden)
 			return
 		}
 
@@ -177,7 +177,7 @@ func auth(auth map[string]string, next http.HandlerFunc) http.HandlerFunc {
 		ht.Write([]byte(APIKey + timestamp + storedSecret))
 		hash := hex.EncodeToString(ht.Sum(nil))
 		if hash != signature {
-			http.Error(w, hash, http.StatusForbidden)
+			http.Error(w, "", http.StatusForbidden)
 			return
 		}
 


### PR DESCRIPTION
New endpoint `/v1_0/image/upload` for image uploading. 

Notes:
* new env var GODINARY_AUTH with apikey,apisecret value
* new middleware for validating auth based in a signature(sha256(apikey+timestamp+secret))
* endpoint with auth should receive apikey, timestamp and signature
* endpoint will answer with final godinary URL
* same image uploaded twice will have two different URLs
* GODINARY_DOMAIN var is requested for building final URLs