### PR TITLE
WIP: reestructure parse function, split parseFilters, parseFormat and parseCrop

### DIFF
--- a/http/views.go
+++ b/http/views.go
@@ -51,7 +51,7 @@ func Fetch(opts *ServerOpts) func(http.ResponseWriter, *http.Request) {
 		acceptHeader, ok := r.Header["Accept"]
 		job.AcceptWebp = ok && strings.Contains(acceptHeader[0], "image/webp")
 
-		if err := job.Parse(urlInfo); err != nil {
+		if err := job.Parse(urlInfo, true); err != nil {
 			raven.CaptureErrorAndWait(err, nil)
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return
@@ -147,7 +147,7 @@ func Upload(opts *ServerOpts) func(http.ResponseWriter, *http.Request) {
 		acceptHeader, ok := r.Header["Accept"]
 		job.AcceptWebp = ok && strings.Contains(acceptHeader[0], "image/webp")
 
-		if err := job.Parse(urlInfo); err != nil {
+		if err := job.Parse(urlInfo, false); err != nil {
 			raven.CaptureErrorAndWait(err, nil)
 			http.Error(w, "Bad request", http.StatusBadRequest)
 			return

--- a/image/job.go
+++ b/image/job.go
@@ -11,6 +11,7 @@ import (
 	bimg "gopkg.in/h2non/bimg.v1"
 )
 
+// Hasher interface
 type Hasher interface {
 	Hash(s string) string
 }
@@ -99,13 +100,10 @@ func (job *Job) parseFilters(s string) error {
 			if job.Target.Format, err = parseFormat(filter[1], job.AcceptWebp); err != nil {
 				return err
 			}
-
 		case "c":
-			crop, err := parseCrop(filter[1])
-			if err != nil {
+			if job.Filters["crop"], err = parseCrop(filter[1]); err != nil {
 				return err
 			}
-			job.Filters["crop"] = crop
 		}
 	}
 	return nil
@@ -128,7 +126,6 @@ func (job *Job) Parse(fetchData string) error {
 		parts = strings.Split(job.Source.URL, "/")
 		job.Source.URL = parts[1]
 	}
-
 	job.Target.Hash = job.Hasher.Hash(fetchData + string(job.Target.Format))
 	job.Source.Hash = job.Hasher.Hash(job.Source.URL)
 

--- a/image/job_test.go
+++ b/image/job_test.go
@@ -20,246 +20,163 @@ var testFiles = map[string]string{
 	"png":  "testdata/baboon.png",
 }
 
-var parserCases = []struct {
-	url         string
-	expected    Job
-	description string
-}{
-	{
-		testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Format: bimg.JPEG,
-				Hash:   "7568485b3a4ec0d74e9f0220d7c83fa4a6e4f1e4399f6903eda9483fdc8cdbc0",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"without filters",
-	},
-	{
-		testSecureURL,
-		Job{
-			Source: Image{
-				URL:  testSecureURL,
-				Hash: "191fef766e83be494e6b7bbd6e205a7ec14e27e43596a8a63c672ca19e7252ba",
-			},
-			Target: Image{
-				Format: bimg.JPEG,
-				Hash:   "fbfcb873e1b899593b0ef2a8a76c44105d08b991a2bf4a99129cde3f2f3c880b",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"without filters secure",
-	},
-	{
-		"w_400/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:  400,
-				Format: bimg.JPEG,
-				Hash:   "7499a3a704204fcc4811d8af480ba2f27916f37132c295687d0e3b9ae2ca992f",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"with one filter",
-	},
-	{
-		"w_400/" + testSecureURL,
-		Job{
-			Source: Image{
-				URL:  testSecureURL,
-				Hash: "191fef766e83be494e6b7bbd6e205a7ec14e27e43596a8a63c672ca19e7252ba",
-			},
-			Target: Image{
-				Width:  400,
-				Format: bimg.JPEG,
-				Hash:   "f5ffba22a3a06cad388892a8564e7a5130a279769b71b9a004e308c2764a6341",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"with one filter secure",
-	},
-	{
-		"w_400,c_limit,h_600,f_jpg/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.JPEG,
-				Hash:   "00f5cefda635ef7e5a657e8363ea3fd15ef90028b9ea2f8372fa828631d506ca",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter jpg",
-	},
-	{
-		"w_400,c_limit,h_600,f_webp,q_50/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:   400,
-				Height:  600,
-				Quality: 50,
-				Format:  bimg.WEBP,
-				Hash:    "ac799d0068df5144351ebed0f03fc846c6263c44cc543d31b8e6b33cc8f10103",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter webp",
-	},
-	{
-		"w_400,c_limit,h_600,f_auto,q_65/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:   400,
-				Height:  600,
-				Quality: 65,
-				Format:  bimg.JPEG,
-				Hash:    "511d78de767e504b5b8c805011ed6e4d9c26ce76f9f36d50ff33e29a96d0c3a4",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter auto jpeg",
-	},
-	{
-		"w_400,c_limit,h_600,f_png/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.PNG,
-				Hash:   "506c667899dc573c359a15d6063bd96f67f006b86f83b207294c51d8fc45affc",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter png",
-	},
-	{
-		"w_400,c_limit,h_600,f_gif/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.GIF,
-				Hash:   "9ed8868e8d61f26e717129d0bac06787041e6048d1dcf5a906c23ac0efa3d4af",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter gif",
-	},
-	{
-		"w_400,c_limit,h_600,f_jpeg/" + testURL,
-		Job{
-			Source: Image{
-				URL:  testURL,
-				Hash: "9c2eb35928a2ee6ab8221c393fd306348b1235e282ecb32f0e41ca1bba6e90a9",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.JPEG,
-				Hash:   "962aa5597fbb18caabfacfee9a1b612ad478341d4e8a573682788b773d874a37",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"with multiple filter jpeg",
-	},
-	{
-		"w_400,c_limit,h_600,f_jpeg/file.jpg",
-		Job{
-			Source: Image{
-				URL:  "file.jpg",
-				Hash: "91a721b7244245b40e368346edc97c311439a0260e4d51f60023eb1bc86d7238",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.JPEG,
-				Hash:   "4d083201587ff3b5b4d268253c5070b650d64051b646a29bc352ea57878eb41b",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"plain uploaded file with multiple filter jpeg",
-	},
-	{
-		"file.jpg",
-		Job{
-			Source: Image{
-				URL:  "file.jpg",
-				Hash: "91a721b7244245b40e368346edc97c311439a0260e4d51f60023eb1bc86d7238",
-			},
-			Target: Image{
-				Format: bimg.JPEG,
-				Hash:   "79fba77d9b83b2a93091d8a50c51e98337ff9f500ada410aef0ed39ceb3b6aad",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"plain uploaded file without filters",
-	},
-	{
-		"w_400,c_limit,h_600,f_jpeg/ffolder/file.jpg",
-		Job{
-			Source: Image{
-				URL:  "file.jpg",
-				Hash: "91a721b7244245b40e368346edc97c311439a0260e4d51f60023eb1bc86d7238",
-			},
-			Target: Image{
-				Width:  400,
-				Height: 600,
-				Format: bimg.JPEG,
-				Hash:   "2ed3a246c9e88ba1f8cae9e3742dd07cd530bd7af76b38b4dac86c97355e6c8c",
-			},
-			Filters: map[string]string{"crop": "limit"},
-		},
-		"plain uploaded foldered file without filters",
-	},
-	{
-		"folder/file.jpg",
-		Job{
-			Source: Image{
-				URL:  "file.jpg",
-				Hash: "91a721b7244245b40e368346edc97c311439a0260e4d51f60023eb1bc86d7238",
-			},
-			Target: Image{
-				Format: bimg.JPEG,
-				Hash:   "e9978594ecc62a2067f73df44128cbdce4e12eee68449342f88765e5355a4972",
-			},
-			Filters: map[string]string{"crop": "scale"},
-		},
-		"plain uploaded foldered file with filters",
-	},
+type FakeHasher struct{}
+
+func (fh *FakeHasher) Hash(s string) string {
+	return ""
 }
 
 func TestParse(t *testing.T) {
-	for _, test := range parserCases {
+	fakeHasher := &FakeHasher{}
+	cases := []struct {
+		url         string
+		expected    Job
+		description string
+	}{
+		{
+			testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"without filters",
+		},
+		{
+			testSecureURL,
+			Job{
+				Source:  Image{URL: testSecureURL, Hash: ""},
+				Target:  Image{Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"without filters secure",
+		},
+		{
+			"w_400/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"with one filter",
+		},
+		{
+			"w_400/" + testSecureURL,
+			Job{
+				Source:  Image{URL: testSecureURL, Hash: ""},
+				Target:  Image{Width: 400, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"with one filter secure",
+		},
+		{
+			"w_400,c_limit,h_600,f_jpg/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter jpg",
+		},
+		{
+			"w_400,c_limit,h_600,f_webp,q_50/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Quality: 50, Format: bimg.WEBP, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter webp",
+		},
+		{
+			"w_400,c_limit,h_600,f_auto,q_65/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Quality: 65, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter auto jpeg",
+		},
+		{
+			"w_400,c_limit,h_600,f_png/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.PNG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter png",
+		},
+		{
+			"w_400,c_limit,h_600,f_gif/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.GIF, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter gif",
+		},
+		{
+			"w_400,c_limit,h_600,f_jpeg/" + testURL,
+			Job{
+				Source:  Image{URL: testURL, Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"with multiple filter jpeg",
+		},
+		{
+			"w_400,c_limit,h_600,f_jpeg/file.jpg",
+			Job{
+				Source:  Image{URL: "file.jpg", Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"plain uploaded file with multiple filter jpeg",
+		},
+		{
+			"file.jpg",
+			Job{
+				Source:  Image{URL: "file.jpg", Hash: ""},
+				Target:  Image{Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"plain uploaded file without filters",
+		},
+		{
+			"w_400,c_limit,h_600,f_jpeg/ffolder/file.jpg",
+			Job{
+				Source:  Image{URL: "file.jpg", Hash: ""},
+				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "limit"},
+				Hasher:  fakeHasher,
+			},
+			"plain uploaded foldered file without filters",
+		},
+		{
+			"folder/file.jpg",
+			Job{
+				Source:  Image{URL: "file.jpg", Hash: ""},
+				Target:  Image{Format: bimg.JPEG, Hash: ""},
+				Filters: map[string]string{"crop": "scale"},
+				Hasher:  fakeHasher,
+			},
+			"plain uploaded foldered file with filters",
+		},
+	}
+	for _, test := range cases {
 		job := NewJob()
+		job.Hasher = fakeHasher
 		err := job.Parse(test.url)
 		assert.Nil(t, err)
 		assert.Equal(t, test.expected, *job, test.description)

--- a/image/job_test.go
+++ b/image/job_test.go
@@ -29,157 +29,30 @@ func (fh *FakeHasher) Hash(s string) string {
 func TestParse(t *testing.T) {
 	fakeHasher := &FakeHasher{}
 	cases := []struct {
-		url         string
-		expected    Job
+		input       string
+		URL         string
 		description string
 	}{
-		{
-			testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"without filters",
-		},
-		{
-			testSecureURL,
-			Job{
-				Source:  Image{URL: testSecureURL, Hash: ""},
-				Target:  Image{Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"without filters secure",
-		},
-		{
-			"w_400/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"with one filter",
-		},
-		{
-			"w_400/" + testSecureURL,
-			Job{
-				Source:  Image{URL: testSecureURL, Hash: ""},
-				Target:  Image{Width: 400, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"with one filter secure",
-		},
-		{
-			"w_400,c_limit,h_600,f_jpg/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter jpg",
-		},
-		{
-			"w_400,c_limit,h_600,f_webp,q_50/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Quality: 50, Format: bimg.WEBP, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter webp",
-		},
-		{
-			"w_400,c_limit,h_600,f_auto,q_65/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Quality: 65, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter auto jpeg",
-		},
-		{
-			"w_400,c_limit,h_600,f_png/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.PNG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter png",
-		},
-		{
-			"w_400,c_limit,h_600,f_gif/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.GIF, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter gif",
-		},
-		{
-			"w_400,c_limit,h_600,f_jpeg/" + testURL,
-			Job{
-				Source:  Image{URL: testURL, Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"with multiple filter jpeg",
-		},
-		{
-			"w_400,c_limit,h_600,f_jpeg/file.jpg",
-			Job{
-				Source:  Image{URL: "file.jpg", Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"plain uploaded file with multiple filter jpeg",
-		},
-		{
-			"file.jpg",
-			Job{
-				Source:  Image{URL: "file.jpg", Hash: ""},
-				Target:  Image{Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"plain uploaded file without filters",
-		},
-		{
-			"w_400,c_limit,h_600,f_jpeg/ffolder/file.jpg",
-			Job{
-				Source:  Image{URL: "file.jpg", Hash: ""},
-				Target:  Image{Width: 400, Height: 600, Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "limit"},
-				Hasher:  fakeHasher,
-			},
-			"plain uploaded foldered file without filters",
-		},
-		{
-			"folder/file.jpg",
-			Job{
-				Source:  Image{URL: "file.jpg", Hash: ""},
-				Target:  Image{Format: bimg.JPEG, Hash: ""},
-				Filters: map[string]string{"crop": "scale"},
-				Hasher:  fakeHasher,
-			},
-			"plain uploaded foldered file with filters",
-		},
+		// fetch cases
+		{testURL, testURL, "fetch without filters"},
+		{testSecureURL, testSecureURL, "fetch secure without filters"},
+		{"w_400/" + testURL, testURL, "fetch with filter"},
+		{"w_400/" + testURL, testURL, "fetch with multiple filter"},
+		{"w_400,c_limit,h_600,f_jpg/" + testSecureURL, testSecureURL, "fetch secure with filter"},
+		{"w_400,c_limit,h_600,f_jpg/" + testSecureURL, testSecureURL, "fetch secure with multiple filter"},
+		// upload cases
+		{"file.jpg", "file.jpg", "upload without filters"},
+		{"folder/file.jpg", "file.jpg", "upload without filters and folder"},
+		{"w_400/file.jpg", "file.jpg", "upload with one filters"},
+		{"w_400,c_limit,h_600,f_jpeg/file.jpg", "file.jpg", "upload with multiple filters"},
+		{"w_400,c_limit,h_600,f_jpeg/folder/file.jpg", "file.jpg", "upload with multiple filters and folder"},
 	}
 	for _, test := range cases {
 		job := NewJob()
 		job.Hasher = fakeHasher
-		err := job.Parse(test.url)
+		err := job.Parse(test.input)
 		assert.Nil(t, err)
-		assert.Equal(t, test.expected, *job, test.description)
+		assert.Equal(t, test.URL, job.Source.URL, test.description)
 	}
 }
 
@@ -193,22 +66,37 @@ func TestParseFilters(t *testing.T) {
 		{
 			"w_400",
 			&Job{Target: Image{Width: 400, Format: bimg.JPEG}, Filters: map[string]string{"crop": "scale"}},
-			nil, "one filter - width",
-		},
-		{
-			"h_400",
-			&Job{Target: Image{Height: 400, Format: bimg.JPEG}, Filters: map[string]string{"crop": "scale"}},
-			nil, "one filter - height",
-		},
-		{
-			"c_limit",
-			&Job{Target: Image{Format: bimg.JPEG}, Filters: map[string]string{"crop": "limit"}},
-			nil, "only crop",
+			nil, "only width",
 		},
 		{
 			"h_400,w_400",
 			&Job{Target: Image{Height: 400, Width: 400, Format: bimg.JPEG}, Filters: map[string]string{"crop": "scale"}},
 			nil, "width - height",
+		},
+		{
+			"f_png",
+			&Job{Target: Image{Format: bimg.PNG}, Filters: map[string]string{"crop": "scale"}},
+			nil, "png format",
+		},
+		{
+			"f_gif",
+			&Job{Target: Image{Format: bimg.GIF}, Filters: map[string]string{"crop": "scale"}},
+			nil, "gif format",
+		},
+		{
+			"f_webp",
+			&Job{Target: Image{Format: bimg.WEBP}, Filters: map[string]string{"crop": "scale"}},
+			nil, "gif format",
+		},
+		{
+			"h_400",
+			&Job{Target: Image{Height: 400, Format: bimg.JPEG}, Filters: map[string]string{"crop": "scale"}},
+			nil, "only height",
+		},
+		{
+			"c_limit",
+			&Job{Target: Image{Format: bimg.JPEG}, Filters: map[string]string{"crop": "limit"}},
+			nil, "only crop",
 		},
 		{
 			"h_400,w_400,f_png,q_55,c_limit",


### PR DESCRIPTION
- [X] split parse function into smaller topic functions 
- [x] split tests for topic functions, keep global parse smaller
- [x] remove hack 2folder from Parse function